### PR TITLE
Seqtokens exact whitespace

### DIFF
--- a/combinator.go
+++ b/combinator.go
@@ -12,23 +12,20 @@ func Seq(parsers ...Parserish) Parser {
 	return NewParser("Seq()", func(ps *State, node *Result) {
 		node.Child = make([]Result, len(parserfied))
 		startpos := ps.Pos
+		var toksSpaces []string
 		for i, parser := range parserfied {
 			parser(ps, &node.Child[i])
 			if ps.Errored() {
 				ps.Pos = startpos
 				return
 			}
+			c := node.Child[i]
+			toksSpaces = append(toksSpaces, ps.Input[ps.WsStart:ps.WsEnd])
+			toksSpaces = append(toksSpaces, c.Token)
 		}
-
-		// Set the token of the node from the children.
-		var toks []string
-		for _, c := range node.Child {
-			if c.Token == "" {
-				continue
-			}
-			toks = append(toks, c.Token)
-		}
-		node.Token = strings.Join(toks, " ")
+		// Set the token of the node from the tokens of the children and the
+		// spaces between them.
+		node.Token = strings.Join(toksSpaces, "")
 	})
 }
 

--- a/combinator_test.go
+++ b/combinator_test.go
@@ -25,6 +25,12 @@ func TestSeq(t *testing.T) {
 		require.Equal(t, 6, p2.Error.pos)
 		require.Equal(t, 0, p2.Pos)
 	})
+
+	t.Run("token matches packed input", func(t *testing.T) {
+		input := "helloworld"
+		node, _ := runParser(input, parser)
+		require.Equal(t, input, node.Token)
+	})
 }
 
 func TestSeqWithMaybes(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -219,10 +219,10 @@ func TestAutoWS(t *testing.T) {
 		require.Equal(t, "offset 0: expected hello", ps.Error.Error())
 	})
 
-	t.Run("ws is can be explicitly consumed ", func(t *testing.T) {
+	t.Run("ws can be explicitly consumed ", func(t *testing.T) {
 		result, ps := runParser(" hello", NoAutoWS(Seq(ASCIIWhitespace, "hello")))
 		require.Equal(t, "hello", result.Child[1].Token)
-		require.Equal(t, "hello", result.Token)
+		require.Equal(t, " hello", result.Token)
 		require.Equal(t, "", ps.Get())
 	})
 

--- a/state.go
+++ b/state.go
@@ -12,6 +12,11 @@ type State struct {
 	Input string
 	// An offset into the string, pointing to the current tip
 	Pos int
+	// WsStart points to the beginning of the latest chunk of whitespace
+	// just before Pos if there was one.
+	WsStart int
+	// WsEnd points to the end (exclusive) of the latest chunk of whitespace.
+	WsEnd int
 	// Do not backtrack past this point
 	Cut int
 	// Error is a secondary return channel from parsers, but used so heavily
@@ -24,6 +29,8 @@ type State struct {
 // ASCIIWhitespace matches any of the standard whitespace characters. It is faster
 // than the UnicodeWhitespace parser as it does not need to decode unicode runes.
 func ASCIIWhitespace(s *State) {
+	s.WsStart = s.Pos
+	defer func() { s.WsEnd = s.Pos }()
 	for s.Pos < len(s.Input) {
 		switch s.Input[s.Pos] {
 		case '\t', '\n', '\v', '\f', '\r', ' ':
@@ -37,6 +44,8 @@ func ASCIIWhitespace(s *State) {
 // UnicodeWhitespace matches any unicode space character. Its a little slower
 // than the ascii parser because it matches a rune at a time.
 func UnicodeWhitespace(s *State) {
+	s.WsStart = s.Pos
+	defer func() { s.WsEnd = s.Pos }()
 	for s.Pos < len(s.Input) {
 		r, w := utf8.DecodeRuneInString(s.Get())
 		if !unicode.IsSpace(r) {
@@ -48,7 +57,10 @@ func UnicodeWhitespace(s *State) {
 
 // NoWhitespace disables automatic whitespace matching
 func NoWhitespace(s *State) {
-
+	// Make sure the whitespace chunk is set to an empty string
+	// so we don't mess up the input reconstruction for Token in Seq().
+	s.WsStart = s.Pos
+	s.WsEnd = s.Pos
 }
 
 // NewState creates a new State from a string


### PR DESCRIPTION
This makes sure the whitespace in any returned Seq() Token matches the input string exactly.